### PR TITLE
Guard Blackwell-specific cuBLAS algorithm constant

### DIFF
--- a/csrc/blackwell_gemm_kernel.cu
+++ b/csrc/blackwell_gemm_kernel.cu
@@ -51,10 +51,11 @@ void launch_production_gemm(
     // Optimized for Blackwell: use appropriate compute type and algorithm
     cublasComputeType_t compute_type = CUBLAS_COMPUTE_32F;
     cublasGemmAlgo_t algo = CUBLAS_GEMM_DEFAULT_TENSOR_OP;
-    
-    // For Blackwell, prefer specific algorithms
-    #ifdef BLACKWELL_ARCH
-    // Use Blackwell-optimized algorithm if available
+
+    // For Blackwell, prefer specific algorithms when supported
+    #if defined(BLACKWELL_ARCH) && defined(CUBLAS_GEMM_ALGO_TENSOR_OP_SM100)
+    // Some cuBLAS releases do not yet ship Blackwell-specific algorithms.
+    // Only use the enum when it exists; otherwise the default above is used.
     algo = CUBLAS_GEMM_ALGO_TENSOR_OP_SM100;  // Blackwell tensor core algorithm
     #endif
     


### PR DESCRIPTION
## Summary
- guard use of `CUBLAS_GEMM_ALGO_TENSOR_OP_SM100` so builds succeed even when the enum isn't available
- clarify that older cuBLAS releases lack Blackwell-specific algorithms and fall back to default

## Testing
- `pytest tests/test_basic_api.py`
- `pytest tests/test_training_api.py`
- `python setup.py build_ext --inplace` *(fails: cuda_runtime.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f31432dc8329af4895d481e421a3